### PR TITLE
Update to spring boot 2.1.0.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.4.3.RELEASE</version>
+		<version>2.1.0.RELEASE</version>
 	</parent>
 
 	<repositories>

--- a/solace-java-sample-app/pom.xml
+++ b/solace-java-sample-app/pom.xml
@@ -29,11 +29,20 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.solace.cloud.core</groupId>
+			<artifactId>solace-services-info</artifactId>
+			<version>0.2.0</version>
+		</dependency>
+		<dependency>
 			<groupId>com.solace.spring.boot</groupId>
 			<artifactId>solace-java-spring-boot-starter</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-
+		<dependency>
+			<groupId>com.solace.cloud.cloudfoundry</groupId>
+			<artifactId>solace-spring-cloud-connector</artifactId>
+			<version>3.0.0</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/solace-java-spring-boot-autoconfigure/pom.xml
+++ b/solace-java-spring-boot-autoconfigure/pom.xml
@@ -44,12 +44,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-core</artifactId>
-			<optional>true</optional>
-		</dependency>
-
-		<dependency>
 		  <groupId>com.solace.cloud.cloudfoundry</groupId>
 		  <artifactId>solace-spring-cloud-connector</artifactId>
 		  <version>3.0.0</version>

--- a/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationTest.java
+++ b/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationTest.java
@@ -127,7 +127,7 @@ public class SolaceJavaAutoConfigurationTest extends SolaceJavaAutoConfiguration
 		assertNotNull(this.context.getBean(SpringJCSMPFactoryCloudFactory.class));
 		assertNotNull(this.context.getBean(SpringJCSMPFactory.class));
 		assertNotNull(this.context.getBean(JCSMPProperties.class));
-		assertNull(this.context.getBean(SolaceServiceCredentials.class));
+		assertEquals( "null", this.context.getBean("findFirstSolaceServiceCredentials" ).toString() );
 	}
 
 	@Test
@@ -136,7 +136,7 @@ public class SolaceJavaAutoConfigurationTest extends SolaceJavaAutoConfiguration
 		assertNotNull(this.context.getBean(SpringJCSMPFactoryCloudFactory.class));
 		assertNotNull(this.context.getBean(SpringJCSMPFactory.class));
 		assertNotNull(this.context.getBean(JCSMPProperties.class));
-		assertNull(this.context.getBean(SolaceServiceCredentials.class));
+		assertEquals( "null", this.context.getBean("findFirstSolaceServiceCredentials" ).toString() );
 	}
 
 }

--- a/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationTestBase.java
+++ b/solace-java-spring-boot-autoconfigure/src/test/java/com/solace/spring/boot/autoconfigure/SolaceJavaAutoConfigurationTestBase.java
@@ -5,7 +5,7 @@ import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
-import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.ResolvableType;
@@ -92,7 +92,7 @@ public abstract class SolaceJavaAutoConfigurationTestBase {
 
     void load(Class<?> config, String... environment) {
         AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
-        EnvironmentTestUtils.addEnvironment(applicationContext, environment);
+        TestPropertyValues.of( environment ).applyTo( applicationContext );
         applicationContext.register(config);
         applicationContext.register(configClass);
         applicationContext.refresh();


### PR DESCRIPTION
Simple changes to allow solace-java-spring-boot to be used with spring boot 2.1.0.  I do not use this in a cloud environment and this time, so I was not able to verify that cloud functionality is not broken.