### PR TITLE
Add ssl_trust_store property to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Any additional Solace Java API properties can be set through configuring `solace
 
 ```
 solace.java.apiProperties.reapply_subscriptions=false
+solace.java.apiProperties.ssl_trust_store=/path/to/truststore
 ```
 
 Note that the direct configuration of `solace.java.` properties takes precedence over the `solace.java.apiProperties.`.


### PR DESCRIPTION
Add api property " apiProperties.ssl_trust_store" example since most users will (hopefully) be using secure communications. 