### PR TITLE
Add spring boot starter to solace starter

### DIFF
--- a/solace-java-spring-boot-starter/pom.xml
+++ b/solace-java-spring-boot-starter/pom.xml
@@ -17,6 +17,10 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.solace.spring.boot</groupId>
 			<artifactId>solace-java-spring-boot-autoconfigure</artifactId>
 			<version>${project.version}</version>


### PR DESCRIPTION
This commit adds `spring-boot-starter` to the starter so that it can be
used in isolation, see[1] for more details.

[1] https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-developing-auto-configuration.html#boot-features-custom-starter-module-starter