### PR TITLE
Upgrade solace-services-info to 0.4.1 & solace-spring-cloud-connector to 4.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Note that you'll neeed to include version 3.1.0 or later to use Spring Boot rele
 
 ```groovy
 // Solace Java API & auto-configuration
-compile("com.solace.spring.boot:solace-java-spring-boot-starter:3.2.0")
+compile("com.solace.spring.boot:solace-java-spring-boot-starter:3.2.1")
 ```
 
 #### Using it with Maven
@@ -56,7 +56,7 @@ compile("com.solace.spring.boot:solace-java-spring-boot-starter:3.2.0")
 <dependency>
 	<groupId>com.solace.spring.boot</groupId>
 	<artifactId>solace-java-spring-boot-starter</artifactId>
-	<version>3.2.0</version>
+	<version>3.2.1</version>
 </dependency>
 ```
 

--- a/solace-java-spring-boot-autoconfigure/pom.xml
+++ b/solace-java-spring-boot-autoconfigure/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>com.solace.cloud.core</groupId>
 			<artifactId>solace-services-info</artifactId>
-			<version>0.4.0</version>
+			<version>0.4.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.solacesystems</groupId>

--- a/solace-java-spring-boot-autoconfigure/pom.xml
+++ b/solace-java-spring-boot-autoconfigure/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 		  <groupId>com.solace.cloud.cloudfoundry</groupId>
 		  <artifactId>solace-spring-cloud-connector</artifactId>
-		  <version>4.1.0</version>
+		  <version>4.1.1</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Fixes transient Jackson dependency issues when Jackson 3.x is present in Maven repositories.